### PR TITLE
Fix entriesAsJSON method of Server class.

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -25,7 +25,7 @@ export default class Server {
 
   entriesAsJSON () {
     const { entriesMap } = this
-    return JSON.stringify(entriesMap.entries())
+    return JSON.stringify(Array.from(entriesMap.values()))
   }
 
   handleRequest = (req, res) => {


### PR DESCRIPTION
It fixes "navigating to `/` (posts list) page on the client side" issue from #5 

Edit: Although client side rendering works on development, doesn't work on exported static version.