### PR TITLE
Add a default data in source-fs configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `source-filesystem` param `data` to add default metadata (extra) for each entry.
 - Tests for source-filesystem.
+- Tests for fetcher.
+### Fixed
+- Issue with `fetcher` function `getPostsByFilter` loading all entries when filter returned no results.
 
 ## [3.1.3] - 2021-07-22
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `source-filesystem` param `data` to add default metadata (extra) for each entry.
+- Tests for source-filesystem.
 
 ## [3.1.3] - 2021-07-22
 ### Fixed

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -46,6 +46,7 @@ This stage compiles an entries list. It should call `action.build` on any entry 
         - name: e.g.`'firts-post.md'`
         - mimeType: e.g.`'text/markdown'`
         - createdOn {Date}
+        - extra {Object} default data to be passed for each entry metadata
         - load() {Promise} return file content
       - `removeOptions` {Object}
         -  filePath: Absolute path
@@ -73,7 +74,7 @@ Create an entry. It should call `action.create` to generate an `Entry` in the **
       - data
         - __id: MD5(meta.filePath)
         - mimeType: meta.mimeType,
-        - page: meta.extra.page || `'post'`
+        - page: meta.extra.page
         - name: meta.name
         - category: meta.extra.category || meta.path
         - date: meta.extra.date || meta.created

--- a/README.md
+++ b/README.md
@@ -390,6 +390,8 @@ module.exports = withNextein({
 
 ```
 
+## Plugins
+
 You can also define nextein plugins using the `withNextein` configuration:
 
 ```js
@@ -408,10 +410,11 @@ module.exports = withNextein({
 
 The `nextein.plugins` configuration accepts an array of plugins with the following formats:
 
-- ` ['plugin-name'] `: Just a string to define the plugin.
-- ` ['plugin-name', {  }] `: A string to define the plugin and a plugins options object.
+- ` [name] `: Just a string to define the plugin.
+- ` [name, options] `: A string to define the plugin and a plugins options object.
+- ` { name, id, options } `: A plugin object. The `name` field is required. All previous definitoins are transformed into this format. The `id` is optional, when provided allows multiple instances of the same plugin.
 
-The plugin name should be a pre-installed plugin (`nextein-plugin-markdown`) , or a local file (`./myplugins/my-awesome-plugin`)
+The plugin `name` should be a pre-installed plugin (`nextein-plugin-markdown`) , or a local file (`./myplugins/my-awesome-plugin`)
 
 ### Default Plugins
 
@@ -465,7 +468,7 @@ Options:
 
 - `field`: Default to`'published'`. Will check if a `field` is present in post `data` and filter if set to `false`.
 
-## Plugins
+### Writing Plugins
 
 You can write your own plugins. There are basically 2 different types (source and transforms). Source plugins will be called to generate the posts entries and then the transform plugins will receive those entries and can modify, filter, append, or transform in anyway the posts list.
 

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ The default configuration includes:
 
 ```js
 plugins: [
-  ['nextein-plugin-source-fs', { path: 'posts' }],
+  ['nextein-plugin-source-fs', { path: 'posts', data: { page: 'post' } }],
   'nextein-plugin-markdown',
   'nextein-plugin-filter-unpublished'
 ]
@@ -433,6 +433,7 @@ Read files from file system.
 Options:
 
 - `path`: Path to read files from.
+- `data`: Default data to be passed as extra for each entry. Default to `{}`
 - `includes`: Default to `**/*.*`. 
 - `ignore`: A set of ignored files. The default list includes:
   ```js

--- a/src/entries/fetcher.js
+++ b/src/entries/fetcher.js
@@ -26,8 +26,8 @@ export async function getData () {
 
 export async function getPostsFilterBy (filter) {
   const _filtered = await dataFilterBy(filter)
-
-  return load(_filtered.map(data => data.__id))
+  const ids = _filtered.map(data => data.__id)
+  return (filter && !ids.length) ? [] : load(ids)
 }
 
 export async function getPosts () {

--- a/src/plugins/config.js
+++ b/src/plugins/config.js
@@ -83,7 +83,7 @@ export function plugins () {
 
 // TODO
 export const getDefaultPlugins = () => [
-  ['nextein-plugin-source-fs', { path: 'posts' }],
+  ['nextein-plugin-source-fs', { path: 'posts', data: { page: 'post' } }],
   'nextein-plugin-markdown',
   'nextein-plugin-filter-unpublished'
 ]

--- a/src/plugins/internals/markdown/index.js
+++ b/src/plugins/internals/markdown/index.js
@@ -25,7 +25,10 @@ function createOptions (source, raw, options) {
   return {
     meta: {
       ...source,
-      extra
+      extra: {
+        ...extra,
+        ...source.extra
+      }
     },
     content,
     raw

--- a/test/unit/entries/create.test.js
+++ b/test/unit/entries/create.test.js
@@ -12,20 +12,23 @@ describe('createEntry', () => {
   }
   const content =  ''
   const raw = ''
+  const expectedDataDefault = {
+    __id: createId(filePath),
+    mimeType: meta.mimeType,
+    page: 'post',
+    name: meta.name,      
+    date: JSON.parse(meta.createdOn),
+    day: '02',
+    month: '02',
+    year: '2020',
+    category: undefined,
+    url: `/${meta.name}`
+  }
 
   test('create default', () => {
     const evaluated = { meta, content, raw }
     const expectedData = {
-      __id: createId(filePath),
-      mimeType: meta.mimeType,
-      page: 'post',
-      name: meta.name,      
-      date: JSON.parse(meta.createdOn),
-      day: '02',
-      month: '02',
-      year: '2020',
-      category: undefined,
-      url: `/${meta.name}`
+      ...expectedDataDefault
     }
     const result = createEntry(evaluated)
 
@@ -36,19 +39,26 @@ describe('createEntry', () => {
     const date = new Date('2010-10-10T20:20:00Z')
     const evaluated = { meta: { ...meta, extra: { date } }, content, raw }
     const expectedData = {
-      __id: createId(filePath),
-      mimeType: meta.mimeType,
-      page: 'post',
-      name: meta.name,      
+      ...expectedDataDefault,
       date,
       day: '10',
       month: '10',
       year: '2010',
-      category: undefined,
-      url: `/${meta.name}`
     }
     const result = createEntry(evaluated)
 
     expect(result).toEqual({ data: expectedData, content, raw })
   })
+
+  test('create with page: "page" in extra', () => {
+    const page = 'page'
+    const evaluated = { meta: { ...meta, extra: { page } }, content, raw }
+    const expectedData = {
+      ...expectedDataDefault,
+      page
+    }
+    const result = createEntry(evaluated)
+
+    expect(result).toEqual({ data: expectedData, content, raw })
+  })  
 })

--- a/test/unit/entries/fetcher.test.js
+++ b/test/unit/entries/fetcher.test.js
@@ -1,0 +1,112 @@
+
+jest.mock('../../../src/entries/load')
+jest.mock('../../../src/entries/metadata')
+
+import { expect, test } from '@jest/globals'
+import fetcher from '../../../src/entries/fetcher'
+import { inCategory } from '../../../src/entries/filters'
+
+import { load } from '../../../src/entries/load'
+import { metadata } from '../../../src/entries/metadata'
+
+describe('fetcher', () => {
+  test('exports fetcher as default', () => {
+    expect(fetcher).toBeDefined()
+  })
+})
+
+describe('fetcher()', () => {
+  beforeEach(() => {
+    load.mockReset()
+  })
+
+  test('fetcher() returns object with static helpers', () => {
+    const actual = fetcher()
+    expect(actual).toHaveProperty('getData')
+    expect(actual).toHaveProperty('getPosts')
+    expect(actual).toHaveProperty('getPost')
+  })
+
+  test('getData() should return all entries metadata', async () => {
+    const { getData } = fetcher()
+    const expected = [{ __id: 1}, { __id: 2}]
+
+    metadata.mockReturnValueOnce(expected)    
+
+    const actual = await getData()
+    expect(actual).toEqual(expected)
+  })
+
+  test('getPosts() should return all entries', async () => {
+    const { getPosts } = fetcher()
+    const expected = [{ data: { __id: 1}, content: ''}]
+
+    metadata.mockReturnValueOnce(expected.map(({ data }) => data))
+    load.mockReturnValueOnce(expected)
+
+    const actual = await getPosts()
+    expect(actual).toEqual(expected)
+  })
+})
+
+describe('fetcher(filter)', () => {
+  const expectedCategory = 'test'
+  const filter = inCategory(expectedCategory)
+
+  beforeEach(() => {
+    load.mockReset()
+  })
+
+  test('fetcher(filter) returns object with static helpers', () => {
+    const actual = fetcher(filter)
+    expect(actual).toHaveProperty('getData')
+    expect(actual).toHaveProperty('getPosts')
+    expect(actual).toHaveProperty('getPost')
+  })
+
+  test('getData() should return all entries metadata by the given filter', async () => {
+    const { getData } = fetcher(filter)
+    const expected = [{ __id: 1, category: expectedCategory}]
+    const meta = [...expected, , { __id: 2}]
+
+    metadata.mockReturnValueOnce(meta)
+
+    const actual = await getData()
+    expect(actual).toEqual(expected)
+  })
+
+  test('getData() should return [] if no entries metadata match the given filter', async () => {
+    const { getData } = fetcher(filter)
+    const expected = []
+    const meta = [...expected, , { __id: 2}]
+
+    metadata.mockReturnValueOnce(meta)
+
+    const actual = await getData()
+    expect(actual).toEqual(expected)
+  })
+
+  test('getPosts() should return all entries by the given filter', async () => {
+    const { getPosts } = fetcher(filter)
+    const expected = [{ data: { __id: 1, category: expectedCategory }, content: ''}]
+    const all = [...expected, { data: { __id: 2 }, content: ''}]
+
+    metadata.mockReturnValueOnce(all.map(({ data }) => data))
+    load.mockReturnValueOnce(expected)
+
+    const actual = await getPosts()
+    expect(actual).toEqual(expected)
+  })
+
+  test('getPosts() should return [] if no entries match the given filter', async () => {
+    const { getPosts } = fetcher(filter)
+    const expected = []
+    const all = [...expected, { data: { __id: 2 }, content: ''}]
+
+    metadata.mockReturnValueOnce(all.map(({ data }) => data))
+    expect(load).not.toBeCalled()
+
+    const actual = await getPosts()
+    expect(actual).toEqual(expected)
+  })
+})

--- a/test/unit/plugins/internals/mardown.test.js
+++ b/test/unit/plugins/internals/mardown.test.js
@@ -1,6 +1,4 @@
 
-import { resolve } from 'path'
-
 import { build } from  '../../../../src//plugins/internals/markdown'
 
 async function load () {

--- a/test/unit/plugins/internals/source-filesystem.test.js
+++ b/test/unit/plugins/internals/source-filesystem.test.js
@@ -1,0 +1,77 @@
+
+import { expect, jest } from '@jest/globals'
+import EventEmitter from 'events'
+
+jest.mock('chokidar')
+jest.mock('fs')
+
+import { watch } from 'chokidar'
+import { statSync } from 'fs'
+
+import { source } from  '../../../../src/plugins/internals/source-filesystem'
+
+describe('source-filesystem::source', () => {
+
+  test('default options', async () => {
+    const path = '__test'
+    
+    watch.mockImplementation(() => {
+      const watcher = new EventEmitter()
+      setTimeout(() => { 
+        watcher.emit('add', `${path}/file.md`)
+        statSync.mockReturnValueOnce({ birthtime: new Date() })
+        watcher.emit('ready')
+      }
+      , 300)
+      return watcher
+    })
+    
+    expect.assertions(8)
+
+    await source({ path }, { build: options => {
+      expect(options).toHaveProperty('filePath')
+      expect(options).toHaveProperty('path')
+      expect(options).toHaveProperty('name')
+      expect(options).toHaveProperty('mimeType')
+      expect(options).toHaveProperty('createdOn')
+      expect(options).toHaveProperty('extra')
+      expect(options).toHaveProperty('load')
+    } })
+    
+    expect(watch).toBeCalled()
+  })
+
+  test('fail if not path in options', async () => {
+    return expect(source({}, {})).rejects.toThrow('path')
+  })
+
+  test('pass data in options', async () => {
+    const path = '__test'
+    const data = { page: false }
+
+    watch.mockImplementation(() => {
+      const watcher = new EventEmitter()
+      setTimeout(() => { 
+        watcher.emit('add', `${path}/file.md`)
+        statSync.mockReturnValueOnce({ birthtime: new Date() })
+        watcher.emit('ready')
+      }
+      , 300)
+      return watcher
+    })
+    
+    expect.assertions(8)
+
+    await source({ path, data }, { build: options => {
+      expect(options).toHaveProperty('filePath')
+      expect(options).toHaveProperty('path')
+      expect(options).toHaveProperty('name')
+      expect(options).toHaveProperty('mimeType')
+      expect(options).toHaveProperty('createdOn')
+      expect(options).toHaveProperty('extra',data)
+      expect(options).toHaveProperty('load')
+    } })
+    
+    expect(watch).toBeCalled()
+  })  
+})


### PR DESCRIPTION
This data field is used to define default data in a post. It can be used to define a default category, or page, among other fields.

Related to #331 